### PR TITLE
Add notes approval and locking for consultations

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -104,6 +104,10 @@ model Consultation {
     recording           String?     @db.VarChar(200)
     transcript          String?  
     AI_summary          String? 
+    notes_approved_at   DateTime?
+    notes_approved_by   String?
+    notes_locked        Boolean     @default(false)
+    notes_status        NotesStatus @default(DRAFT)
 
     appointment Appointment @relation(fields: [appointment_id], references: [appointment_id])
 
@@ -164,6 +168,12 @@ enum AppointmentStatus {
     pending_reschedule
     completed
     cancelled
+}
+
+enum NotesStatus {
+    DRAFT
+    APPROVED
+    FINAL
 }
 
 model Availability {

--- a/backend/src/consultations/consultations.controller.ts
+++ b/backend/src/consultations/consultations.controller.ts
@@ -124,6 +124,15 @@ export class ConsultationsController {
     return this.consultationsService.updateNotes(userId, consultationId, updateDto);
   }
 
+  @Put(':consultationId/approve-notes')
+  async approveNotes(
+    @Req() req,
+    @Param('consultationId', ParseIntPipe) consultationId: number,
+  ) {
+    const userId = req.user?.userId || req.user?.sub;
+    return this.consultationsService.approveNotes(userId, consultationId);
+  }
+
   // Action Items endpoints
   @Get(':consultationId/action-items')
   async getActionItems(

--- a/backend/src/consultations/consultations.service.ts
+++ b/backend/src/consultations/consultations.service.ts
@@ -395,6 +395,11 @@ export class ConsultationsService {
       throw new NotFoundException('Consultation not found');
     }
 
+    // Check if notes are locked
+    if (consultation.notes_locked) {
+      throw new ForbiddenException('Cannot edit notes that have been approved and locked');
+    }
+
     // Check if doctor owns this consultation
     if (consultation.appointment.doctor_id !== user.doctor_profile.doctor_id) {
       throw new ForbiddenException('You do not have access to update this consultation');
@@ -412,6 +417,81 @@ export class ConsultationsService {
     return {
       transcript: updatedConsultation.transcript || '',
       summary: updatedConsultation.AI_summary || '',
+    };
+  }
+
+  async approveNotes(
+    userId: string,
+    consultationId: number,
+  ): Promise<{ success: boolean; approvedAt: Date; status: string }> {
+    const user = await prisma.user.findUnique({
+      where: { user_id: userId },
+      include: { doctor_profile: true },
+    });
+
+    if (!user) {
+      throw new ForbiddenException('User not found');
+    }
+
+    // Only doctors can approve notes
+    if (!user.doctor_profile) {
+      throw new ForbiddenException('Only doctors can approve consultation notes');
+    }
+
+    const consultation = await prisma.consultation.findUnique({
+      where: { consultation_id: consultationId },
+      include: { appointment: true },
+    });
+
+    if (!consultation) {
+      throw new NotFoundException('Consultation not found');
+    }
+
+    // Check if doctor owns this consultation
+    if (consultation.appointment.doctor_id !== user.doctor_profile.doctor_id) {
+      throw new ForbiddenException('You do not have access to approve this consultation');
+    }
+
+    // Check if already approved
+    if (consultation.notes_locked) {
+      throw new ForbiddenException('Notes have already been approved and locked');
+    }
+
+    // Check if notes exist
+    if (!consultation.AI_summary && !consultation.transcript) {
+      throw new ForbiddenException('Cannot approve consultation without notes');
+    }
+
+    const approvedAt = new Date();
+
+    // Approve and lock notes
+    await prisma.consultation.update({
+      where: { consultation_id: consultationId },
+      data: {
+        notes_approved_at: approvedAt,
+        notes_approved_by: userId,
+        notes_locked: true,
+        notes_status: 'FINAL',
+      },
+    });
+
+    // Audit log
+    try {
+      await this.auditService.log({
+        userId,
+        action: 'CONSULTATION_EDIT',
+        resourceType: 'Consultation',
+        resourceId: consultationId.toString(),
+        details: { message: 'Doctor approved and locked consultation notes', status: 'FINAL' },
+      });
+    } catch (err) {
+      console.error('Failed to log approval audit:', err);
+    }
+
+    return {
+      success: true,
+      approvedAt,
+      status: 'FINAL',
     };
   }
 

--- a/frontend/src/features/consultations/api.ts
+++ b/frontend/src/features/consultations/api.ts
@@ -11,6 +11,10 @@ export interface Consultation {
   recordings?: ConsultationRecording[];
   transcript?: string | null;
   AI_summary?: string | null;
+  notes_approved_at?: string | null;
+  notes_approved_by?: string | null;
+  notes_locked?: boolean;
+  notes_status?: 'DRAFT' | 'APPROVED' | 'FINAL';
   appointment: Appointment;
 }
 
@@ -85,6 +89,21 @@ export async function updateConsultationNotes(
   const response = await apiClient.put<ConsultationNotes>(
     `/consultations/${consultationId}/notes`,
     notes,
+  );
+  return response.data;
+}
+
+export interface ApproveNotesResponse {
+  success: boolean;
+  approvedAt: string;
+  status: string;
+}
+
+export async function approveConsultationNotes(
+  consultationId: number,
+): Promise<ApproveNotesResponse> {
+  const response = await apiClient.put<ApproveNotesResponse>(
+    `/consultations/${consultationId}/approve-notes`,
   );
   return response.data;
 }

--- a/frontend/src/features/consultations/pages/ConsultationSession.tsx
+++ b/frontend/src/features/consultations/pages/ConsultationSession.tsx
@@ -8,6 +8,7 @@ import {
   getConsultationByAppointment,
   generateConsultationNotes,
   updateConsultationNotes,
+  approveConsultationNotes,
   type Consultation,
   type ConsultationNotes,
 } from '../api';
@@ -32,6 +33,7 @@ export const ConsultationSession: React.FC = () => {
   const [savingNotes, setSavingNotes] = useState(false);
   const [notesError, setNotesError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
+  const [approving, setApproving] = useState(false);
   const [showActionItems, setShowActionItems] = useState(true); // Показати по дефолту
   const isDoctor = currentUser?.role === 'doctor';
 
@@ -172,6 +174,38 @@ export const ConsultationSession: React.FC = () => {
       setNotesError(err?.response?.data?.message || 'Failed to save notes');
     } finally {
       setSavingNotes(false);
+    }
+  };
+
+  const handleApproveNotes = async () => {
+    if (!consultation) return;
+
+    try {
+      setApproving(true);
+      setNotesError(null);
+      const result = await approveConsultationNotes(consultation.consultation_id);
+
+      // Reflect locked state in UI
+      setConsultation({
+        ...consultation,
+        notes_locked: true,
+        notes_status: result.status as Consultation['notes_status'],
+        notes_approved_at: result.approvedAt,
+        notes_approved_by: currentUser?.user_id || currentUser?.id || null,
+      });
+
+      // Prevent further edits
+      if (editableNotes) {
+        setEditableNotes({ ...editableNotes });
+      }
+
+      setSaveSuccess(true);
+      setTimeout(() => setSaveSuccess(false), 3000);
+    } catch (err: any) {
+      console.error('Failed to approve notes:', err);
+      setNotesError(err?.response?.data?.message || 'Failed to approve notes');
+    } finally {
+      setApproving(false);
     }
   };
 
@@ -323,7 +357,7 @@ export const ConsultationSession: React.FC = () => {
               <div className={styles.notesContent}>
                 <div className={styles.notesSection}>
                   <h3>AI Summary</h3>
-                  {isDoctor ? (
+                  {isDoctor && !consultation?.notes_locked ? (
                     <textarea
                       className={styles.editableText}
                       value={editableNotes.summary}
@@ -337,7 +371,15 @@ export const ConsultationSession: React.FC = () => {
                     <div className={styles.notesText}>{editableNotes.summary}</div>
                   )}
                 </div>
-                {isDoctor && (
+                {consultation?.notes_approved_at && (
+                  <div className={styles.note}>
+                    Approved on {new Date(consultation.notes_approved_at).toLocaleString('en-US', {
+                      dateStyle: 'medium',
+                      timeStyle: 'short',
+                    })}
+                  </div>
+                )}
+                {isDoctor && !consultation?.notes_locked && (
                   <div className={styles.notesActions}>
                     <Button
                       variant="primary"
@@ -345,6 +387,13 @@ export const ConsultationSession: React.FC = () => {
                       disabled={savingNotes || !editableNotes}
                     >
                       {savingNotes ? 'Saving...' : 'Save Changes'}
+                    </Button>
+                    <Button
+                      variant="secondary"
+                      onClick={handleApproveNotes}
+                      disabled={approving || savingNotes || !editableNotes}
+                    >
+                      {approving ? 'Approving...' : 'Approve & Lock'}
                     </Button>
                   </div>
                 )}


### PR DESCRIPTION
Introduces fields and logic to support approval and locking of consultation notes. Backend now prevents editing locked notes and provides an endpoint for doctors to approve notes, updating status and audit logs. Frontend updates UI to reflect approval state, disables editing after approval, and adds an 'Approve & Lock' action for doctors.