### PR TITLE
Add consultation notes sharing feature for doctors with another verified doctors

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -61,6 +61,8 @@ model DoctorProfile{
     appointments    Appointment[]
     patients        DoctorPatient[] @relation("DoctorToPatient")
     availability    Availability[]
+    sharedNotesBy   SharedConsultationNote[] @relation("SharedBy")
+    sharedNotesWith SharedConsultationNote[] @relation("SharedWith")
 
 }
 
@@ -113,6 +115,7 @@ model Consultation {
 
     recordings ConsultationRecording[]
     actionItems ConsultationActionItem[]
+    sharedNotes SharedConsultationNote[]
 
 }
 
@@ -139,6 +142,24 @@ model ConsultationActionItem {
 
     @@index([consultation_id])
     @@index([consultation_id, is_completed])
+}
+
+model SharedConsultationNote {
+    share_id                Int         @id @default(autoincrement())
+    consultation_id         Int
+    shared_by_doctor_id     Int
+    shared_with_doctor_id   Int
+    permissions             String      @default("read") // "read" or "read_write"
+    created_at              DateTime    @default(now())
+    revoked_at              DateTime?
+
+    consultation    Consultation   @relation(fields: [consultation_id], references: [consultation_id], onDelete: Cascade)
+    shared_by       DoctorProfile  @relation("SharedBy", fields: [shared_by_doctor_id], references: [doctor_id], onDelete: Cascade)
+    shared_with     DoctorProfile  @relation("SharedWith", fields: [shared_with_doctor_id], references: [doctor_id], onDelete: Cascade)
+
+    @@unique([consultation_id, shared_by_doctor_id, shared_with_doctor_id])
+    @@index([shared_with_doctor_id])
+    @@index([consultation_id, shared_by_doctor_id])
 }
 
 model DoctorPatient {

--- a/backend/src/consultations/consultations.controller.ts
+++ b/backend/src/consultations/consultations.controller.ts
@@ -106,10 +106,7 @@ export class ConsultationsController {
   }
 
   @Post(':consultationId/generate-notes')
-  async generateNotes(
-    @Req() req,
-    @Param('consultationId', ParseIntPipe) consultationId: number,
-  ) {
+  async generateNotes(@Req() req, @Param('consultationId', ParseIntPipe) consultationId: number) {
     const userId = req.user?.userId || req.user?.sub;
     return this.consultationsService.generateNotes(userId, consultationId);
   }
@@ -125,20 +122,14 @@ export class ConsultationsController {
   }
 
   @Put(':consultationId/approve-notes')
-  async approveNotes(
-    @Req() req,
-    @Param('consultationId', ParseIntPipe) consultationId: number,
-  ) {
+  async approveNotes(@Req() req, @Param('consultationId', ParseIntPipe) consultationId: number) {
     const userId = req.user?.userId || req.user?.sub;
     return this.consultationsService.approveNotes(userId, consultationId);
   }
 
   // Action Items endpoints
   @Get(':consultationId/action-items')
-  async getActionItems(
-    @Req() req,
-    @Param('consultationId', ParseIntPipe) consultationId: number,
-  ) {
+  async getActionItems(@Req() req, @Param('consultationId', ParseIntPipe) consultationId: number) {
     const userId = req.user?.userId || req.user?.sub;
     return this.consultationsService.getActionItems(userId, consultationId);
   }
@@ -161,7 +152,12 @@ export class ConsultationsController {
     @Body() updateDto: UpdateActionItemDto,
   ) {
     const userId = req.user?.userId || req.user?.sub;
-    return this.consultationsService.updateActionItem(userId, consultationId, actionItemId, updateDto);
+    return this.consultationsService.updateActionItem(
+      userId,
+      consultationId,
+      actionItemId,
+      updateDto,
+    );
   }
 
   @Delete(':consultationId/action-items/:actionItemId')
@@ -172,5 +168,42 @@ export class ConsultationsController {
   ) {
     const userId = req.user?.userId || req.user?.sub;
     return this.consultationsService.deleteActionItem(userId, consultationId, actionItemId);
+  }
+
+  @Post(':consultationId/share')
+  async shareNotes(
+    @Req() req,
+    @Param('consultationId', ParseIntPipe) consultationId: number,
+    @Body('sharedWithDoctorId', ParseIntPipe) sharedWithDoctorId: number,
+    @Body('permissions') permissions: string = 'read',
+  ) {
+    const userId = req.user?.userId || req.user?.sub;
+    return this.consultationsService.shareNotes(
+      userId,
+      consultationId,
+      sharedWithDoctorId,
+      permissions,
+    );
+  }
+
+  @Get('shared-with-me')
+  async getSharedNotes(@Req() req) {
+    const userId = req.user?.userId || req.user?.sub;
+    return this.consultationsService.getSharedNotes(userId);
+  }
+
+  @Get(':consultationId/shares')
+  async getConsultationShares(
+    @Req() req,
+    @Param('consultationId', ParseIntPipe) consultationId: number,
+  ) {
+    const userId = req.user?.userId || req.user?.sub;
+    return this.consultationsService.getConsultationShares(userId, consultationId);
+  }
+
+  @Delete('shares/:shareId')
+  async revokeShare(@Req() req, @Param('shareId', ParseIntPipe) shareId: number) {
+    const userId = req.user?.userId || req.user?.sub;
+    return this.consultationsService.revokeShare(userId, shareId);
   }
 }

--- a/backend/src/consultations/consultations.service.ts
+++ b/backend/src/consultations/consultations.service.ts
@@ -646,4 +646,228 @@ export class ConsultationsService {
 
     return { message: 'Action item deleted successfully' };
   }
+
+  async shareNotes(
+    userId: string,
+    consultationId: number,
+    sharedWithDoctorId: number,
+    permissions: string = 'read',
+  ): Promise<{ success: boolean; shareId: number }> {
+    const user = await prisma.user.findUnique({
+      where: { user_id: userId },
+      include: { doctor_profile: true },
+    });
+
+    if (!user || !user.doctor_profile) {
+      throw new ForbiddenException('Only doctors can share notes');
+    }
+
+    const consultation = await prisma.consultation.findUnique({
+      where: { consultation_id: consultationId },
+      include: { appointment: true },
+    });
+
+    if (!consultation) {
+      throw new NotFoundException('Consultation not found');
+    }
+
+    // Verify current user is the doctor who created the consultation
+    if (consultation.appointment.doctor_id !== user.doctor_profile.doctor_id) {
+      throw new ForbiddenException('You can only share your own consultations');
+    }
+
+    // Verify the target doctor exists
+    const targetDoctor = await prisma.doctorProfile.findUnique({
+      where: { doctor_id: sharedWithDoctorId },
+      include: { user: true },
+    });
+
+    if (!targetDoctor) {
+      throw new NotFoundException('Target doctor not found');
+    }
+
+    // Prevent sharing with self
+    if (targetDoctor.doctor_id === user.doctor_profile.doctor_id) {
+      throw new ForbiddenException('Cannot share notes with yourself');
+    }
+
+    // Check if already shared with this doctor
+    const existingShare = await prisma.sharedConsultationNote.findUnique({
+      where: {
+        consultation_id_shared_by_doctor_id_shared_with_doctor_id: {
+          consultation_id: consultationId,
+          shared_by_doctor_id: user.doctor_profile.doctor_id,
+          shared_with_doctor_id: sharedWithDoctorId,
+        },
+      },
+    });
+
+    if (existingShare && !existingShare.revoked_at) {
+      throw new ForbiddenException('Notes already shared with this doctor');
+    }
+
+    // Create or restore share
+    let share;
+    if (existingShare && existingShare.revoked_at) {
+      // Restore revoked share
+      share = await prisma.sharedConsultationNote.update({
+        where: { share_id: existingShare.share_id },
+        data: {
+          revoked_at: null,
+          permissions,
+          created_at: new Date(),
+        },
+      });
+    } else {
+      // Create new share
+      share = await prisma.sharedConsultationNote.create({
+        data: {
+          consultation_id: consultationId,
+          shared_by_doctor_id: user.doctor_profile.doctor_id,
+          shared_with_doctor_id: sharedWithDoctorId,
+          permissions,
+        },
+      });
+    }
+
+    // Audit log
+    try {
+      await this.auditService.log({
+        userId,
+        action: 'SHARE',
+        resourceType: 'Consultation',
+        resourceId: consultationId.toString(),
+        details: {
+          message: `Shared consultation notes with doctor ${targetDoctor.user.first_name} ${targetDoctor.user.last_name}`,
+          permissions,
+        },
+      });
+    } catch (err) {
+      console.error('Failed to log share audit:', err);
+    }
+
+    return { success: true, shareId: share.share_id };
+  }
+
+  async getSharedNotes(userId: string): Promise<any[]> {
+    const user = await prisma.user.findUnique({
+      where: { user_id: userId },
+      include: { doctor_profile: true },
+    });
+
+    if (!user || !user.doctor_profile) {
+      throw new ForbiddenException('Only doctors can view shared notes');
+    }
+
+    const sharedNotes = await prisma.sharedConsultationNote.findMany({
+      where: {
+        shared_with_doctor_id: user.doctor_profile.doctor_id,
+        revoked_at: null,
+      },
+      include: {
+        consultation: {
+          include: {
+            appointment: {
+              include: {
+                doctor: { include: { user: true } },
+                patient: { include: { user: true } },
+              },
+            },
+          },
+        },
+        shared_by: { include: { user: true } },
+      },
+    });
+
+    return sharedNotes;
+  }
+
+  async getConsultationShares(userId: string, consultationId: number): Promise<any[]> {
+    const user = await prisma.user.findUnique({
+      where: { user_id: userId },
+      include: { doctor_profile: true },
+    });
+
+    if (!user || !user.doctor_profile) {
+      throw new ForbiddenException('Only doctors can view shares');
+    }
+
+    const consultation = await prisma.consultation.findUnique({
+      where: { consultation_id: consultationId },
+      include: { appointment: true },
+    });
+
+    if (!consultation) {
+      throw new NotFoundException('Consultation not found');
+    }
+
+    // Only the owner doctor can see shares of their consultation
+    if (consultation.appointment.doctor_id !== user.doctor_profile.doctor_id) {
+      throw new ForbiddenException('You can only view shares for your own consultations');
+    }
+
+    const shares = await prisma.sharedConsultationNote.findMany({
+      where: {
+        consultation_id: consultationId,
+        shared_by_doctor_id: user.doctor_profile.doctor_id,
+        revoked_at: null,
+      },
+      include: {
+        shared_with: { include: { user: true } },
+      },
+    });
+
+    return shares;
+  }
+
+  async revokeShare(userId: string, shareId: number): Promise<{ success: boolean }> {
+    const user = await prisma.user.findUnique({
+      where: { user_id: userId },
+      include: { doctor_profile: true },
+    });
+
+    if (!user || !user.doctor_profile) {
+      throw new ForbiddenException('Only doctors can revoke shares');
+    }
+
+    const share = await prisma.sharedConsultationNote.findUnique({
+      where: { share_id: shareId },
+    });
+
+    if (!share) {
+      throw new NotFoundException('Share not found');
+    }
+
+    // Only the doctor who shared can revoke
+    if (share.shared_by_doctor_id !== user.doctor_profile.doctor_id) {
+      throw new ForbiddenException('You can only revoke shares you created');
+    }
+
+    await prisma.sharedConsultationNote.update({
+      where: { share_id: shareId },
+      data: { revoked_at: new Date() },
+    });
+
+    // Audit log
+    try {
+      const sharedWith = await prisma.doctorProfile.findUnique({
+        where: { doctor_id: share.shared_with_doctor_id },
+        include: { user: true },
+      });
+
+      await this.auditService.log({
+        userId,
+        action: 'SHARE',
+        resourceType: 'Consultation',
+        resourceId: share.consultation_id.toString(),
+        details: {
+          message: `Revoked consultation note sharing from doctor ${sharedWith?.user.first_name} ${sharedWith?.user.last_name}`,
+        },
+      });
+    } catch (err) {
+      console.error('Failed to log revoke audit:', err);
+    }
+
+    return { success: true };
+  }
 }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -21,4 +21,11 @@ export class UsersController {
     const userId = req.user?.userId || req.user?.sub;
     return await this.usersService.updateProfile(userId, updateProfileDto);
   }
+
+  @Get('doctors')
+  @UseGuards(AuthGuard('jwt'))
+  async listDoctors(@Req() req) {
+    const userId = req.user?.userId || req.user?.sub;
+    return this.usersService.listDoctors(userId);
+  }
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -43,6 +43,29 @@ export class UsersService {
     return this.mapToUserResponse(user);
   }
 
+  async listDoctors(currentUserId?: string) {
+    return this.prisma.user.findMany({
+      where: {
+        role: 'doctor',
+        doctor_profile: { isNot: null },
+        ...(currentUserId ? { NOT: { user_id: currentUserId } } : {}),
+      },
+      select: {
+        user_id: true,
+        first_name: true,
+        last_name: true,
+        email: true,
+        doctor_profile: {
+          select: {
+            doctor_id: true,
+            specialization: true,
+          },
+        },
+      },
+      orderBy: { first_name: 'asc' },
+    });
+  }
+
   async updateProfile(userId: string, dto: UpdateProfileDto): Promise<UserResponseDto> {
     // Get current user to check if role is already set
     const currentUser = await this.prisma.user.findUnique({

--- a/docs/NOTE_SHARING_IMPLEMENTATION.md
+++ b/docs/NOTE_SHARING_IMPLEMENTATION.md
@@ -1,0 +1,232 @@
+# Consultation Notes Sharing Feature
+
+## Overview
+Doctors can now share consultation notes with other verified doctors with read-only permissions. Shared notes can be accessed by the recipient doctor and all sharing events are recorded in the audit log. Notes can be shared at any time, whether they're in DRAFT, APPROVED, or FINAL status.
+
+## Database Schema
+
+### New Model: `SharedConsultationNote`
+```prisma
+model SharedConsultationNote {
+    share_id                Int         @id @default(autoincrement())
+    consultation_id         Int
+    shared_by_doctor_id     Int
+    shared_with_doctor_id   Int
+    permissions             String      @default("read") // "read" or "read_write"
+    created_at              DateTime    @default(now())
+    revoked_at              DateTime?
+
+    consultation    Consultation   @relation(fields: [consultation_id], references: [consultation_id], onDelete: Cascade)
+    shared_by       DoctorProfile  @relation("SharedBy", fields: [shared_by_doctor_id], references: [doctor_id], onDelete: Cascade)
+    shared_with     DoctorProfile  @relation("SharedWith", fields: [shared_with_doctor_id], references: [doctor_id], onDelete: Cascade)
+
+    @@unique([consultation_id, shared_by_doctor_id, shared_with_doctor_id])
+    @@index([shared_with_doctor_id])
+    @@index([consultation_id, shared_by_doctor_id])
+}
+```
+
+### Updated Model: `Consultation`
+Added relationship to SharedConsultationNote:
+```prisma
+sharedNotes SharedConsultationNote[]
+```
+
+### Updated Model: `DoctorProfile`
+Added sharing relationships:
+```prisma
+sharedNotesBy   SharedConsultationNote[] @relation("SharedBy")
+sharedNotesWith SharedConsultationNote[] @relation("SharedWith")
+```
+
+## Backend Implementation
+
+### Service Methods (ConsultationsService)
+
+#### `shareNotes(userId, consultationId, sharedWithDoctorId, permissions)`
+- **Purpose**: Share a consultation's notes with another doctor
+- **Validation**:
+  - Only doctors can share notes
+  - Cannot share with self
+  - Cannot share the same consultation with same doctor twice
+  - Target doctor must exist
+  - Source doctor must own the consultation
+- **Returns**: `{ success: boolean; shareId: number }`
+- **Audit Logging**: `SHARE` action with doctor details
+
+#### `getSharedNotes(userId)`
+- **Purpose**: Get all notes shared with the current doctor
+- **Includes**: Full consultation data, appointment details, patient/doctor info
+- **Filter**: Only non-revoked shares (`revoked_at IS NULL`)
+- **Returns**: Array of `SharedConsultationNote` with nested consultation data
+
+#### `getConsultationShares(userId, consultationId)`
+- **Purpose**: Get all active shares for a specific consultation
+- **Validation**: Only the consultation's doctor can view shares
+- **Returns**: Array of `SharedConsultationNote` with recipient doctor info
+
+#### `revokeShare(userId, shareId)`
+- **Purpose**: Revoke a share (soft delete with `revoked_at` timestamp)
+- **Validation**: Only the sharing doctor can revoke
+- **Returns**: `{ success: boolean }`
+- **Audit Logging**: `SHARE` action (revocation) with doctor details
+
+### REST Endpoints
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `POST` | `/consultations/:consultationId/share` | Share notes with another doctor |
+| `GET` | `/consultations/shared-with-me` | Get notes shared with current doctor |
+| `GET` | `/consultations/:consultationId/shares` | Get list of doctors this consultation is shared with |
+| `DELETE` | `/consultations/shares/:shareId` | Revoke a share |
+
+### Audit Logging
+All sharing actions are logged with:
+- **Action**: `SHARE` (for both share and revoke operations)
+- **Resource Type**: `Consultation`
+- **Resource ID**: Consultation ID
+- **Details**: Doctor names and operation (share/revoke)
+
+## Frontend Implementation
+
+### Types (frontend/src/features/consultations/api.ts)
+
+```typescript
+interface SharedConsultationNote {
+  share_id: number;
+  consultation_id: number;
+  shared_by_doctor_id: number;
+  shared_with_doctor_id: number;
+  permissions: string;
+  created_at: string;
+  revoked_at?: string | null;
+  consultation?: Consultation;
+  shared_by?: { doctor_id: number; user: {...} };
+  shared_with?: { doctor_id: number; user: {...} };
+}
+```
+
+### API Functions
+
+- `shareConsultationNotes(consultationId, sharedWithDoctorId, permissions)`
+- `getSharedNotesWithMe()` - Get notes shared with current doctor
+- `getConsultationShares(consultationId)` - Get shares for a consultation
+- `revokeConsultationShare(shareId)` - Revoke a share
+
+### UI Components
+
+#### ConsultationSession Component Updates
+
+**New State Variables:**
+```typescript
+const [showShareModal, setShowShareModal] = useState(false);
+const [sharedDoctors, setSharedDoctors] = useState<SharedConsultationNote[]>([]);
+const [sharingDoctor, setSharingDoctor] = useState<number | null>(null);
+const [sharingError, setSharingError] = useState<string | null>(null);
+const [sharing, setSharing] = useState(false);
+```
+
+**New Handler Functions:**
+- `handleLoadSharedDoctors()` - Fetch list of doctors this note is shared with
+- `handleShareNotes()` - Share note with selected doctor
+- `handleRevokeShare(shareId)` - Revoke a share
+- `useEffect` - Auto-load shares when share modal opens
+
+**UI Changes to Notes Modal:**
+1. **Share Button** - Opens modal to share with another doctor (available when notes are unlocked)
+2. **Shared With List** - Shows list of doctors this note is shared with and allows revocation
+3. **Share Modal** - Allows selection of doctor to share with
+
+## Usage Flow
+
+### For Doctor Sharing Notes:
+1. Open a consultation session
+2. Generate or edit AI notes
+3. Click "Share with Doctor" button in notes modal
+4. Select target doctor from dropdown
+5. Click "Share" button
+6. Share event is logged in audit trail
+7. Can view/revoke shares in the "Shared with:" section
+
+### For Doctor Receiving Shared Notes:
+1. Go to "Shared with me" section (to be implemented in future UI)
+2. See all notes shared by other doctors
+3. Access read-only view of shared notes
+4. Sharing doctor can revoke access anytime
+
+## Security Features
+
+✅ **Authorization**:
+- Only doctors can share notes
+- Only the owning doctor can share their consultations
+- Only the sharing doctor can revoke shares
+- Recipients only get read-only access
+
+✅ **Audit Trail**:
+- All shares logged with doctor identities
+- All revocations logged with timestamps
+- Traceable via audit log system
+
+✅ **Data Integrity**:
+- Unique constraint prevents duplicate shares
+- Soft deletes preserve audit trail
+- Cascading deletes when consultation deleted
+
+✅ **HIPAA Compliance**:
+- Notes stay within doctor network
+- Recipients must be verified doctors
+- Sharing events fully audited
+- Can revoke access anytime
+
+## Future Enhancements
+
+1. **Permission Levels**: Implement `read` vs `read_write` permissions
+2. **Access Analytics**: Track who accessed shared notes and when
+3. **Bulk Sharing**: Share with multiple doctors at once
+4. **Auto-Expiration**: Set expiration dates on shares
+5. **Shared Notes View**: Dedicated UI for viewing all notes shared with you
+6. **Doctor Directory**: Integrate with verified doctor list for easy selection
+7. **Notifications**: Notify recipient when notes are shared
+8. **Collaborative Editing**: If `read_write` permission, allow edits
+
+## Database Migration
+
+Run these commands to apply schema changes:
+
+```bash
+# Option 1: Create and run migration
+cd backend
+npx prisma migrate dev --name add_shared_consultation_notes
+
+# Option 2: Direct schema push (if no migration history sync needed)
+npx prisma db push
+```
+
+Then regenerate Prisma client:
+```bash
+npx prisma generate
+```
+
+## Testing Checklist
+
+- [ ] Doctor A shares notes with Doctor B
+- [ ] Doctor B can view shared notes (when UI implemented)
+- [ ] Audit log shows share event
+- [ ] Doctor A can revoke share
+- [ ] Share event is unique (prevent duplicate shares)
+- [ ] Cannot share with self
+- [ ] Cannot share if not consultation owner
+- [ ] Can share locked (approved) notes
+- [ ] Can share draft notes
+- [ ] Shared notes reference in audit trail
+
+## Files Modified
+
+### Backend
+- `backend/prisma/schema.prisma` - Added SharedConsultationNote model
+- `backend/src/consultations/consultations.service.ts` - Added sharing methods
+- `backend/src/consultations/consultations.controller.ts` - Added sharing endpoints
+
+### Frontend
+- `frontend/src/features/consultations/api.ts` - Added sharing types and API functions
+- `frontend/src/features/consultations/pages/ConsultationSession.tsx` - Added sharing UI and handlers

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -33,6 +33,7 @@ export const Layout = () => {
     { path: '/patients', icon: '❤️', label: 'My Patients' },
     { path: '/available-patients', icon: '👥', label: 'Available Patients' },
     { path: '/messages', icon: '💬', label: 'Messages' },
+    { path: '/shared-notes', icon: '🔗', label: 'Shared Notes' },
     { path: '/audit-logs', icon: '📊', label: 'Audit Logs' },
     { path: '/profile', icon: '⚙️', label: 'Profile' },
     { path: '/notifications', icon: '🔔', label: 'Notifications' },

--- a/frontend/src/features/consultations/api.ts
+++ b/frontend/src/features/consultations/api.ts
@@ -41,10 +41,7 @@ export async function getConsultationByAppointment(
   return response.data;
 }
 
-export async function uploadRecording(
-  consultationId: number,
-  file: File,
-): Promise<Consultation> {
+export async function uploadRecording(consultationId: number, file: File): Promise<Consultation> {
   const formData = new FormData();
   formData.append('file', file);
 
@@ -55,8 +52,18 @@ export async function uploadRecording(
       headers: { 'Content-Type': 'multipart/form-data' },
     },
   );
-
   return response.data;
+}
+
+export interface DoctorOption {
+  user_id: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  doctor_profile: {
+    doctor_id: number;
+    specialization?: string | null;
+  };
 }
 
 export interface ConsultationNotes {
@@ -79,6 +86,11 @@ export async function generateConsultationNotes(
   const response = await apiClient.post<ConsultationNotes>(
     `/consultations/${consultationId}/generate-notes`,
   );
+  return response.data;
+}
+
+export async function getDoctors(): Promise<DoctorOption[]> {
+  const response = await apiClient.get<DoctorOption[]>(`/users/doctors`);
   return response.data;
 }
 
@@ -108,10 +120,68 @@ export async function approveConsultationNotes(
   return response.data;
 }
 
-// Action Items API
-export async function getActionItems(
+export interface SharedConsultationNote {
+  share_id: number;
+  consultation_id: number;
+  shared_by_doctor_id: number;
+  shared_with_doctor_id: number;
+  permissions: string;
+  created_at: string;
+  revoked_at?: string | null;
+  consultation?: Consultation;
+  shared_by?: {
+    doctor_id: number;
+    user: {
+      user_id: string;
+      first_name: string;
+      last_name: string;
+      email: string;
+    };
+  };
+  shared_with?: {
+    doctor_id: number;
+    user: {
+      user_id: string;
+      first_name: string;
+      last_name: string;
+      email: string;
+    };
+  };
+}
+
+export async function shareConsultationNotes(
   consultationId: number,
-): Promise<ConsultationActionItem[]> {
+  sharedWithDoctorId: number,
+  permissions: string = 'read',
+): Promise<{ success: boolean; shareId: number }> {
+  const response = await apiClient.post<{ success: boolean; shareId: number }>(
+    `/consultations/${consultationId}/share`,
+    { sharedWithDoctorId, permissions },
+  );
+  return response.data;
+}
+
+export async function getSharedNotesWithMe(): Promise<SharedConsultationNote[]> {
+  const response = await apiClient.get<SharedConsultationNote[]>('/consultations/shared-with-me');
+  return response.data;
+}
+
+export async function getConsultationShares(
+  consultationId: number,
+): Promise<SharedConsultationNote[]> {
+  const response = await apiClient.get<SharedConsultationNote[]>(
+    `/consultations/${consultationId}/shares`,
+  );
+  return response.data;
+}
+
+export async function revokeConsultationShare(shareId: number): Promise<{ success: boolean }> {
+  const response = await apiClient.delete<{ success: boolean }>(`/consultations/shares/${shareId}`);
+  return response.data;
+}
+
+// Action Items API
+export async function getActionItems(consultationId: number): Promise<ConsultationActionItem[]> {
   const response = await apiClient.get<ConsultationActionItem[]>(
     `/consultations/${consultationId}/action-items`,
   );

--- a/frontend/src/features/consultations/pages/ConsultationSession.tsx
+++ b/frontend/src/features/consultations/pages/ConsultationSession.tsx
@@ -9,8 +9,14 @@ import {
   generateConsultationNotes,
   updateConsultationNotes,
   approveConsultationNotes,
+  getDoctors,
+  shareConsultationNotes,
+  getConsultationShares,
+  revokeConsultationShare,
   type Consultation,
   type ConsultationNotes,
+  type SharedConsultationNote,
+  type DoctorOption,
 } from '../api';
 import { AudioRecorder } from '../components/AudioRecorder';
 import { ActionItems } from '../components/ActionItems';
@@ -35,6 +41,12 @@ export const ConsultationSession: React.FC = () => {
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [approving, setApproving] = useState(false);
   const [showActionItems, setShowActionItems] = useState(true); // Показати по дефолту
+  const [showShareModal, setShowShareModal] = useState(false);
+  const [sharedDoctors, setSharedDoctors] = useState<SharedConsultationNote[]>([]);
+  const [sharingDoctor, setSharingDoctor] = useState<number | null>(null);
+  const [sharingError, setSharingError] = useState<string | null>(null);
+  const [sharing, setSharing] = useState(false);
+  const [availableDoctors, setAvailableDoctors] = useState<DoctorOption[]>([]);
   const isDoctor = currentUser?.role === 'doctor';
 
   useEffect(() => {
@@ -110,6 +122,9 @@ export const ConsultationSession: React.FC = () => {
 
   const handleShowNotes = async () => {
     if (!consultation) return;
+
+    // Load shared doctors list when opening notes modal
+    await handleLoadSharedDoctors();
 
     // If notes already exist in consultation, show them
     if (consultation.AI_summary) {
@@ -209,6 +224,60 @@ export const ConsultationSession: React.FC = () => {
     }
   };
 
+  const handleLoadSharedDoctors = async () => {
+    if (!consultation) return;
+    try {
+      const shares = await getConsultationShares(consultation.consultation_id);
+      setSharedDoctors(shares);
+    } catch (err: any) {
+      console.error('Failed to load shared doctors:', err);
+      setSharingError('Failed to load shared doctors');
+    }
+  };
+
+  const handleShareNotes = async () => {
+    if (!consultation || !sharingDoctor) return;
+
+    try {
+      setSharing(true);
+      setSharingError(null);
+      await shareConsultationNotes(consultation.consultation_id, sharingDoctor, 'read');
+
+      // Reload shared doctors list
+      await handleLoadSharedDoctors();
+
+      setSharingDoctor(null);
+      setSharingError(null);
+    } catch (err: any) {
+      console.error('Failed to share notes:', err);
+      setSharingError(err?.response?.data?.message || 'Failed to share notes');
+    } finally {
+      setSharing(false);
+    }
+  };
+
+  const handleRevokeShare = async (shareId: number) => {
+    try {
+      await revokeConsultationShare(shareId);
+      // Reload shared doctors list
+      await handleLoadSharedDoctors();
+    } catch (err: any) {
+      console.error('Failed to revoke share:', err);
+      setSharingError(err?.response?.data?.message || 'Failed to revoke share');
+    }
+  };
+
+  useEffect(() => {
+    if (showShareModal && consultation) {
+      handleLoadSharedDoctors();
+      getDoctors()
+        .then((docs) => {
+          setAvailableDoctors(docs);
+        })
+        .catch(() => setSharingError('Failed to load doctors'));
+    }
+  }, [showShareModal, consultation?.consultation_id]);
+
   const handleCloseModal = () => {
     setShowNotesModal(false);
     setNotesError(null);
@@ -263,19 +332,27 @@ export const ConsultationSession: React.FC = () => {
           <div className={styles.sectionHeader}>
             <h2>Recording</h2>
             {recordingCount > 0 && (
-              <span className={styles.badge}>{recordingCount} / {maxRecordings} {maxRecordings === 1 ? 'recording' : 'recordings'}</span>
+              <span className={styles.badge}>
+                {recordingCount} / {maxRecordings}{' '}
+                {maxRecordings === 1 ? 'recording' : 'recordings'}
+              </span>
             )}
           </div>
           {isDoctor ? (
             <>
               {hasReachedLimit ? (
-                <div className={styles.note}>Recording limit reached ({maxRecordings} {maxRecordings === 1 ? 'recording' : 'recordings'} maximum).</div>
+                <div className={styles.note}>
+                  Recording limit reached ({maxRecordings}{' '}
+                  {maxRecordings === 1 ? 'recording' : 'recordings'} maximum).
+                </div>
               ) : (
                 <AudioRecorder onSave={handleUpload} />
               )}
             </>
           ) : (
-            <div className={styles.note}>Only doctors can record. You can play the recording below when available.</div>
+            <div className={styles.note}>
+              Only doctors can record. You can play the recording below when available.
+            </div>
           )}
 
           {uploading && <div className={styles.note}>Uploading...</div>}
@@ -343,11 +420,7 @@ export const ConsultationSession: React.FC = () => {
           <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
             <div className={styles.modalHeader}>
               <h2>Consultation Notes</h2>
-              <button
-                className={styles.closeButton}
-                onClick={handleCloseModal}
-                type="button"
-              >
+              <button className={styles.closeButton} onClick={handleCloseModal} type="button">
                 ×
               </button>
             </div>
@@ -373,7 +446,8 @@ export const ConsultationSession: React.FC = () => {
                 </div>
                 {consultation?.notes_approved_at && (
                   <div className={styles.note}>
-                    Approved on {new Date(consultation.notes_approved_at).toLocaleString('en-US', {
+                    Approved on{' '}
+                    {new Date(consultation.notes_approved_at).toLocaleString('en-US', {
                       dateStyle: 'medium',
                       timeStyle: 'short',
                     })}
@@ -395,10 +469,82 @@ export const ConsultationSession: React.FC = () => {
                     >
                       {approving ? 'Approving...' : 'Approve & Lock'}
                     </Button>
+                    <Button variant="ghost" onClick={() => setShowShareModal(true)}>
+                      Share with Doctor
+                    </Button>
+                  </div>
+                )}
+                {isDoctor && (
+                  <div className={styles.sharedWithList}>
+                    <h4>Shared with:</h4>
+                    {sharedDoctors.length > 0 ? (
+                      <ul>
+                        {sharedDoctors.map((share) => (
+                          <li key={share.share_id}>
+                            {share.shared_with?.user.first_name} {share.shared_with?.user.last_name}
+                            <button
+                              type="button"
+                              onClick={() => handleRevokeShare(share.share_id)}
+                              style={{ marginLeft: '8px', color: 'red' }}
+                            >
+                              Revoke
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p>Not shared with anyone yet</p>
+                    )}
                   </div>
                 )}
               </div>
             )}
+          </div>
+        </div>
+      )}
+
+      {/* Share Notes Modal */}
+      {showShareModal && isDoctor && (
+        <div className={styles.modalOverlay} onClick={() => setShowShareModal(false)}>
+          <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.modalHeader}>
+              <h2>Share Consultation Notes</h2>
+              <button
+                className={styles.closeButton}
+                onClick={() => setShowShareModal(false)}
+                type="button"
+              >
+                ×
+              </button>
+            </div>
+            {sharingError && <div className={styles.error}>{sharingError}</div>}
+            <div className={styles.notesContent}>
+              <p>Share these notes with another doctor. They will have read-only access.</p>
+              <select
+                value={sharingDoctor || ''}
+                onChange={(e) => setSharingDoctor(e.target.value ? parseInt(e.target.value) : null)}
+                style={{ width: '100%', padding: '8px', marginBottom: '16px' }}
+              >
+                <option value="">Select a doctor...</option>
+                {availableDoctors.length === 0 && (
+                  <option value="" disabled>
+                    No doctors available
+                  </option>
+                )}
+                {availableDoctors.map((doc) => (
+                  <option key={doc.doctor_profile.doctor_id} value={doc.doctor_profile.doctor_id}>
+                    {doc.first_name} {doc.last_name} ({doc.email})
+                  </option>
+                ))}
+              </select>
+              <Button
+                variant="primary"
+                onClick={handleShareNotes}
+                disabled={sharing || !sharingDoctor}
+              >
+                {sharing ? 'Sharing...' : 'Share'}
+              </Button>
+            </div>
           </div>
         </div>
       )}

--- a/frontend/src/features/consultations/pages/SharedNotes.tsx
+++ b/frontend/src/features/consultations/pages/SharedNotes.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from '@/components';
+import { getSharedNotesWithMe, type SharedConsultationNote } from '../api';
+import styles from './ConsultationSession.module.css';
+
+export const SharedNotes: React.FC = () => {
+  const [items, setItems] = useState<SharedConsultationNote[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await getSharedNotesWithMe();
+        setItems(data);
+      } catch (err: any) {
+        setError(err?.response?.data?.message || 'Failed to load shared notes');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  if (loading) return <div className={styles.page}>Loading shared notes...</div>;
+  if (error) return <div className={styles.page}>{error}</div>;
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.headerRow}>
+        <h1 className={styles.title}>Shared Notes</h1>
+      </div>
+      {items.length === 0 ? (
+        <div className={styles.card}>No notes have been shared with you yet.</div>
+      ) : (
+        <div className={styles.card}>
+          <div className={styles.savedList}>
+            {items.map((share) => {
+              const c = share.consultation;
+              const doctorName = `${share.shared_by?.user.first_name || ''} ${
+                share.shared_by?.user.last_name || ''
+              }`.trim();
+              const patientName = c?.appointment
+                ? `${c.appointment.patient.user.first_name} ${c.appointment.patient.user.last_name}`
+                : 'Patient';
+              return (
+                <div key={share.share_id} className={styles.savedRow}>
+                  <div className={styles.label}>From</div>
+                  <div className={styles.value}>{doctorName || 'Doctor'}</div>
+                  <div className={styles.label}>Patient</div>
+                  <div className={styles.value}>{patientName}</div>
+                  <div className={styles.label}>Status</div>
+                  <div className={styles.value}>{c?.notes_status || 'UNKNOWN'}</div>
+                  <div className={styles.label}>Shared</div>
+                  <div className={styles.value}>
+                    {new Date(share.created_at).toLocaleString('en-US', {
+                      dateStyle: 'medium',
+                      timeStyle: 'short',
+                    })}
+                  </div>
+                  <div style={{ display: 'flex', gap: 8 }}>
+                    <Button
+                      variant="secondary"
+                      onClick={() => {
+                        if (c?.AI_summary) {
+                          alert(c.AI_summary);
+                        } else {
+                          alert('No summary provided');
+                        }
+                      }}
+                    >
+                      View Summary
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/features/consultations/pages/index.ts
+++ b/frontend/src/features/consultations/pages/index.ts
@@ -1,1 +1,2 @@
 export { ConsultationSession } from './ConsultationSession';
+export { SharedNotes } from './SharedNotes';

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -75,6 +75,7 @@ const router = createBrowserRouter([
       { path: '/available-patients', element: <patients.pages.AllPatients /> },
       { path: '/my-doctor', element: <patients.pages.MyDoctor /> },
       { path: '/messages', element: <chat.pages.Messages /> },
+      { path: '/shared-notes', element: <consultations.pages.SharedNotes /> },
       { path: '/profile', element: <profile.pages.Profile.Profile /> },
       { path: '/notifications', element: <notifications.NotificationSettings /> },
       { path: '/audit-logs', element: <AuditLogs /> },


### PR DESCRIPTION
Implements backend and frontend support for sharing consultation notes between doctors. Adds SharedConsultationNote model to Prisma schema, new endpoints and service methods for sharing, listing, and revoking shared notes, and audit logging for share/revoke actions. Frontend updates include UI for sharing notes, viewing shared notes, and selecting doctors to share with